### PR TITLE
Add switchy command line

### DIFF
--- a/docs/callgen.rst
+++ b/docs/callgen.rst
@@ -77,7 +77,7 @@ as it's first hop with a destination of ourselves using the default
 *external* profile and the *FreeSWITCH* built in *park* application for
 the outbound session's post-connect execution::
 
-    >>> originator.clients[0].set_orig_cmd(
+    >>> originator.pool.clients[0].set_orig_cmd(
         dest_url='doggy@hostnameA:5080,
         profile='external',
         app_name='park',

--- a/docs/cmdline.rst
+++ b/docs/cmdline.rst
@@ -1,0 +1,108 @@
+Switchy Command Line
+====================
+Switchy provides a convenient cli to initiate load tests with the help
+of click_. The program is installed as `switchy`::
+
+    $ switchy
+    Usage: switchy [OPTIONS] COMMAND [ARGS]...
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      list-apps
+      plot
+      run
+
+A few sub-commands are provided.
+For example you can list the applications available (*apps* determine call flows)::
+
+    $ switchy list-apps
+    Collected 5 built-in apps from 7 modules:
+
+    switchy.apps.bert:
+
+    `Bert`: Call application which runs the bert test application on both legs of a call
+
+        See the docs for `mod_bert`_ and discussion by the author `here`_.
+
+        .. _mod_bert:
+            https://freeswitch.org/confluence/display/FREESWITCH/mod_bert
+        .. _here:
+            https://github.com/moises-silva/freeswitch/issues/1
+
+    switchy.apps.players:
+
+    `TonePlay`: Play a 'milli-watt' tone on the outbound leg and echo it back on the inbound
+
+    `PlayRec`: Play a recording to the callee and record it onto the local file system
+
+        This app can be used in tandem with MOS scoring to verify audio quality.
+        The filename provided must exist in the FreeSWITCH sounds directory such that
+        ${FS_CONFIG_ROOT}/${sound_prefix}/<category>/<filename> points to a valid wave file.
+
+    switchy.apps.dtmf:
+
+    `DtmfChecker`: Play dtmf tones as defined by the iterable attr `sequence` with tone `duration`.
+        Verify the rx sequence matches what was transmitted.  For each session which is answered start
+        a sequence check. For any session that fails digit matching store it locally in the `failed` attribute.
+
+    switchy.apps.routers:
+
+    `Bridger`: Bridge sessions within a call an arbitrary number of times.  
+
+
+The applications listed can be used with the `--app` option to the `run` sub-command.
+`run` is the main sub-command used to start a load test. Here is the help::
+
+    $ switchy run --help
+    Usage: switchy run [OPTIONS] SLAVES...
+
+    Options:
+      --proxy TEXT                    Hostname or IP address of the proxy device
+                                      (this is usually the device you are testing)
+                                      [required]
+      --profile TEXT                  Profile to use for outbound calls in the
+                                      load slaves
+      --rate TEXT                     Call rate
+      --limit TEXT                    Maximum number of concurrent calls
+      --max-offered TEXT              Maximum number of calls to place before
+                                      stopping the program
+      --duration TEXT                 Duration of calls in seconds
+      --interactive / --non-interactive
+                                      Whether to jump into an interactive session
+                                      after setting up the call originator
+      --debug / --no-debug            Whether to enable debugging
+      --app TEXT                      Switchy application to execute (see list-
+                                      apps command to list available apps)
+      --metrics-file TEXT             Store metrics at the given file location
+      --help                          Show this message and exit.
+
+
+The `SLAVES` argument can be one or more IP's or hostnames for each configured FreeSWITCH :term:`slave`
+used to originate traffic. The `--proxy` option is required and must be the IP address or hostname
+of the device you are testing. All slaves will direct traffic to the specified proxy.
+
+The other options are not strictly required but typically you will want to at least specify a given call rate
+using the `--rate` option, max number of concurrent calls (erlangs) with `--limit` and possibly max number of
+calls offered with `--max-offered`.
+
+For example, to start a test using an slave located at `1.1.1.1` to test device at `2.2.2.2` with a maximum of
+`2000` calls at `30` calls per second and stopping after placing `100,000` calls you can do::
+
+    $ switchy run 1.1.1.1 --profile external --proxy 2.2.2.2 --rate 30 --limit 2000 --max-offered 100000
+
+    Slave 1.1.1.1 SIP address is at 1.1.1.1:5080
+    Starting load test for server 2.2.2.2 at 30cps using 1 slaves
+    ...
+
+Note that the `--profile` option is also important and the profile must exist already for all specified slaves.
+
+In this case the call duration would be automatically calculated to sustain that call rate and that max calls
+exactly, but you can tweak the call duration in seconds using the `--duration` option.
+
+Additionally you can use the `--metrics-file` option to store call metrics in a file.
+You can then use the `plot` sub-command to generate graphs of the collected data using
+`matplotlib` if installed.
+
+.. _click: http://click.pocoo.org/5/

--- a/docs/fsconfig.rst
+++ b/docs/fsconfig.rst
@@ -77,7 +77,31 @@ to route SIP sessions back to the :term:`originator`::
 
 This could alternatively be implemented using a :ref:`Switchy app <proxyapp>`
 
-For more information see *FreeSWITCH* `dialplans`_
+When testing FreeSWITCH you will typically want to raise the max-sessions
+and sessions-per-second parameters in autoload_configs/switch.conf.xml::
+
+    <param name="max-sessions" value="20000"/>
+    <!--Most channels to create per second -->
+    <param name="sessions-per-second" value="1000"/>
+
+This avoids FreeSWITCH to start rejecting calls for high loads. However, if your intention
+is to see how FreeSWITCH behaves when reaches those parameters limits, you can set them to
+a value that suits those purposes.
+
+In order to reduce load due to logging it's recommended you reduce your core logging level. This is
+also done in autoload_configs/switch.conf.xml::
+
+    <!-- Default Global Log Level - value is one of debug,info,notice,warning,err,crit,alert -->
+    <param name="loglevel" value="warning"/>
+
+You will want to also raise the file descriptor count::
+
+  # ulimit -n 1000000
+
+You have to make this in the same shell where you start FreeSWITCH. This ensures FreeSWITCH will not
+run out of file descriptors when making hundreds of calls.
+
+For more information see *FreeSWITCH* `dialplans`_ and `performance`_
 
 Typically for load testing this is the recommended routing to employ and
 roughly diagrams to something like::
@@ -98,3 +122,5 @@ roughly diagrams to something like::
     https://freeswitch.org/confluence/display/FREESWITCH/Configuring+FreeSWITCH#ConfiguringFreeSWITCH-SIPProfiles
 .. _dialplans:
     https://freeswitch.org/confluence/display/FREESWITCH/Configuring+FreeSWITCH#ConfiguringFreeSWITCH-Dialplan
+.. _performance:
+    https://freeswitch.org/confluence/display/FREESWITCH/Performance+Testing+and+Configurations

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,6 +7,39 @@
 
 Quick-Start - Originating a single call
 =======================================
+| Assuming you've gone through the required :doc:`deployment steps
+  <fsconfig>` to setup at least one slave, initiating a call becomes
+  very simple using the switchy command line::
+
+    $ switchy run slave.host1 slave.host2 --profile external --proxy sip-device-host --rate 1 --limit 1 --max-offered 1
+
+    ...probably some call generator setup related logging...
+
+    Aug 26 21:59:01 [INFO] switchy cli.py:114 : Slave sip-cannon.qa.sangoma.local SIP address is at 10.10.8.19:5080
+    Aug 26 21:59:01 [INFO] switchy cli.py:114 : Slave vm-host.qa.sangoma.local SIP address is at 10.10.8.21:5080
+    Aug 26 21:59:01 [INFO] switchy cli.py:120 : Starting load test for server dut-008.qa.sangoma.local at 1cps using 2 slaves
+    <Originator: active-calls=0 state=INITIAL total-originated-sessions=0 rate=1 limit=1 max-offered=1 duration=30>
+
+    ...call generator state machine logging...
+
+    <Originator: active-calls=1 state=STOPPED total-originated-sessions=1 rate=1 limit=1 max-offered=1 duration=30>
+    Waiting on 1 active calls to finish
+    Waiting on 1 active calls to finish
+    Waiting on 1 active calls to finish
+    Waiting on 1 active calls to finish
+    Load test finished!
+
+
+| The switchy `run` sub-command takes several options and a list
+  of slaves (or at least one) IP address or hostname. In this
+  example switchy connected to the specified slaves, found the specified SIP
+  profile and initiated a single call with a duration fo 30 seconds to the
+  device under test (set with the `--proxy` option).
+
+| For more information on the switchy command line see :doc:`command line <cmdline>`.
+
+Originating a single call programatically from Python
+=====================================================
 | Making a call with Switchy is quite simple using the built-in
   :py:func:`~switchy.sync.sync_caller` context manager.
 | Assuming you've gone through the required :doc:`deployment steps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e
 
-# docs gen
+# docs gen without requiring ESL.py
 mock
 
 # testing

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,12 @@ setup(
         'switchy.apps.measure',
         # 'tests',
     ],
+    entry_points={
+        'console_scripts': [
+            'switchy = switchy.cli:cli',
+        ]
+    },
+    install_requires=['click'],
     package_data={
         'switchy': ['../conf/switchydp.xml']
     },

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python2.7
 from setuptools import setup
-import switchy
 
 
 with open('README.rst') as f:
@@ -8,14 +7,14 @@ with open('README.rst') as f:
 
 
 setup(
-    name="Switchy",
-    version=switchy.__version__,
+    name="switchy",
+    version='0.1.alpha',
     description='Switchy is a fast FreeSWITCH ESL control library with '
                 'an emphasis on load testing.',
     long_description=readme,
     license='Mozilla',
-    author=switchy.__author__[0],
-    author_email=switchy.__author__[1],
+    author='Sangoma Technologies',
+    author_email='qa@eng.sangoma.com',
     url='https://github.com/sangoma/switchy',
     platforms=['linux'],
     packages=[

--- a/switchy/__init__.py
+++ b/switchy/__init__.py
@@ -10,6 +10,7 @@ Fast FreeSWITCH ESL control with a focus on load testing.
 The `EventListener` was inspired from Moises Silva's
 'fs_test' project: https://github.com/moises-silva/fs_test
 """
+import apps
 from os import path
 from utils import get_logger, ESLError
 from observe import EventListener, Client, get_listener

--- a/switchy/apps/__init__.py
+++ b/switchy/apps/__init__.py
@@ -1,6 +1,113 @@
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80 smarttab expandtab
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 '''
 Built-in applications
 '''
+from .. import utils, marks
+from collections import OrderedDict
+import itertools
+import operator
+
+# registry
+_apps = OrderedDict()
+
+
+def app(*args, **kwargs):
+    '''Decorator to register switchy application classes.
+       Example usage:
+
+       @app
+       class CoolAppController(object):
+           pass
+
+       This will register the class as a switchy app.
+       The name of the app defaults to `class.__name__`.
+       The help for the app is taken from `class.__doc__`.
+
+       You can also provide an alternative name via a
+       decorator argument:
+
+       @app('CoolName')
+       class CoolAppController(object):
+           pass
+
+       or with a keyword arg:
+
+       @app(name='CoolName')
+       class CoolAppController(object):
+           pass
+    '''
+    name = kwargs.get('name')
+    if len(args) >= 1:
+        arg0 = args[0]
+        if type(arg0) is type:
+            return register(arg0, None)
+        name = arg0
+        # if len(args) > 1:
+        #     tail = args[1:]
+
+    def inner(cls):
+        return register(cls, name=name)
+    return inner
+
+
+def register(cls, name=None):
+    """Register an app in the global registry
+    """
+    if not marks.has_callbacks(cls):
+        raise ValueError(
+            "{} contains no defined handlers or callbacks?".format(cls)
+        )
+    app = _apps.setdefault(name or cls.__name__, cls)
+    if cls is not app:
+        raise ValueError("An app '{}' already exists with name '{}'"
+                         .format(app, name))
+    return cls
+
+
+def iterapps():
+    """Iterable over all registered apps.
+    """
+    return itertools.chain(_apps.values())
+
+
+def groupbymod():
+    """Return an iterable which delivers tuples (<modulename>, <apps_subiter>)
+    """
+    return itertools.groupby(
+        _apps.items(),
+        utils.compose(
+            operator.attrgetter('__module__'),
+            operator.itemgetter(1)
+        )
+    )
+
+
+def get(name):
+    """Get a registered app by name or None if one isn't registered.
+    """
+    return _apps.get(name)
+
+
+def load(packages=(), imp_excs=('numpy',)):
+    """Load by importing all built-in apps along with any apps found in the
+    provided `packages` list.
+
+    :param packages: package (names or actual modules)
+    :type package: str | module
+    :rtype: dict[str, types.ModuleType]
+    """
+    apps_map = {}
+    # load built-ins + extras
+    for path, app in utils.iter_import_submods(
+        (__name__,) + packages,
+        imp_excs=imp_excs,
+    ):
+        if isinstance(app, ImportError):
+            utils.log_to_stderr().warn("'{}' failed to load - {}\n".format(
+                path, app.message))
+        else:
+            apps_map[path] = app
+    return apps_map

--- a/switchy/apps/bert.py
+++ b/switchy/apps/bert.py
@@ -9,6 +9,7 @@ from ..apps import app
 from ..marks import event_callback
 from ..utils import get_logger
 
+
 @app
 class Bert(object):
     """Call application which runs the bert test application on both

--- a/switchy/apps/bert.py
+++ b/switchy/apps/bert.py
@@ -5,10 +5,11 @@
 Bert testing
 """
 from collections import deque
+from ..apps import app
 from ..marks import event_callback
 from ..utils import get_logger
 
-
+@app
 class Bert(object):
     """Call application which runs the bert test application on both
     legs of a call

--- a/switchy/apps/call_gen.py
+++ b/switchy/apps/call_gen.py
@@ -242,12 +242,12 @@ class Originator(object):
     def __repr__(self):
         """Repr with [<state>] <load_settings> slapped in
         """
-        props = "rate limit max_offered duration".split()
+        props = "state total_originated_sessions rate limit max_offered duration".split()
         rep = type(self).__name__
-        return "<{0}: '{2}' active calls, state=[{1}], {3}>".format(
-            rep, self.state, self.pool.fast_count(),
+        return "<{}: active-calls={} {}>".format(
+            rep, self.pool.fast_count(),
             " ".join("{}={}".format(
-                attr, getattr(self, attr)) for attr in props)
+                attr.replace('_', '-'), getattr(self, attr)) for attr in props)
         )
 
     def _stop_on_none(self):

--- a/switchy/apps/dtmf.py
+++ b/switchy/apps/dtmf.py
@@ -5,10 +5,11 @@
 Dtmf tools
 """
 from collections import deque, OrderedDict
+from ..apps import app
 from ..marks import event_callback
 from ..utils import get_logger
 
-
+@app
 class DtmfChecker(object):
     '''Play dtmf tones as defined by the iterable attr `sequence` with
     tone `duration`. Verify the rx sequence matches what was transmitted.

--- a/switchy/apps/dtmf.py
+++ b/switchy/apps/dtmf.py
@@ -9,6 +9,7 @@ from ..apps import app
 from ..marks import event_callback
 from ..utils import get_logger
 
+
 @app
 class DtmfChecker(object):
     '''Play dtmf tones as defined by the iterable attr `sequence` with

--- a/switchy/apps/measure/metrics.py
+++ b/switchy/apps/measure/metrics.py
@@ -163,7 +163,7 @@ except ImportError:
         "Matplotlib must be installed for graphing support"
     )
 else:
-    def plot(self):
+    def plot(self, block=False):
             view = self.view
             view.sort(order='time')  # sort array by time stamp
             self.mng, self.fig, self.artists = multiplot(view, fieldspec=[
@@ -179,7 +179,7 @@ else:
                 # rates
                 ('inst_rate', (3, 1)),
                 ('wm_rate', (3, 1)),
-            ])
+            ], block=block)
     # attach a plot method
     CallMetrics.plot = plot
 

--- a/switchy/apps/measure/mpl_helpers.py
+++ b/switchy/apps/measure/mpl_helpers.py
@@ -17,6 +17,7 @@ from ... import utils
 
 log = utils.get_logger(__name__)
 
+
 def multiplot(metrics, fieldspec=None, fig=None, mng=None, block=False):
     '''Plot all columns in appropriate axes on a figure
     (talk about reimplementing `pandas` like an dufus...)

--- a/switchy/apps/measure/mpl_helpers.py
+++ b/switchy/apps/measure/mpl_helpers.py
@@ -8,15 +8,16 @@ Measurement and plotting tools - numpy + mpl helpers
 #     - figure.tight_layout doesn't seem to work??
 #     - make legend malleable
 #     - consider a way to easily move lines to different axes and
+import sys
 from os.path import basename
 import matplotlib.pyplot as plt
 import numpy as np
+import pylab
 from ... import utils
 
 log = utils.get_logger(__name__)
 
-
-def multiplot(metrics, fieldspec=None, fig=None, mng=None):
+def multiplot(metrics, fieldspec=None, fig=None, mng=None, block=False):
     '''Plot all columns in appropriate axes on a figure
     (talk about reimplementing `pandas` like an dufus...)
     '''
@@ -66,9 +67,14 @@ def multiplot(metrics, fieldspec=None, fig=None, mng=None):
 
     # show in a window full size
     fig.tight_layout()
-    fig.show()
     if getattr(metrics, 'title', None):
         fig.suptitle(basename(metrics.title), fontsize=15)
+    if block or sys.platform.lower() == 'darwin':
+        # For MacOS only blocking mode is supported
+        # the fig.show() method throws exceptions
+        pylab.show()
+    else:
+        fig.show()
     return mng, fig, artists
 
 

--- a/switchy/apps/players.py
+++ b/switchy/apps/players.py
@@ -6,10 +6,11 @@ Common testing call flows
 """
 import inspect
 from collections import OrderedDict, namedtuple
+from ..apps import app
 from ..marks import event_callback
 from ..utils import get_logger
 
-
+@app
 class TonePlay(object):
     """Play a 'milli-watt' tone on the outbound leg and echo it back
     on the inbound
@@ -32,7 +33,7 @@ class TonePlay(object):
 
 RecInfo = namedtuple("RecInfo", "host caller callee")
 
-
+@app
 class PlayRec(object):
     '''Play a recording to the callee and record it onto the local file system
 

--- a/switchy/apps/players.py
+++ b/switchy/apps/players.py
@@ -10,6 +10,7 @@ from ..apps import app
 from ..marks import event_callback
 from ..utils import get_logger
 
+
 @app
 class TonePlay(object):
     """Play a 'milli-watt' tone on the outbound leg and echo it back
@@ -32,6 +33,7 @@ class TonePlay(object):
 
 
 RecInfo = namedtuple("RecInfo", "host caller callee")
+
 
 @app
 class PlayRec(object):

--- a/switchy/apps/routers.py
+++ b/switchy/apps/routers.py
@@ -6,9 +6,10 @@ Routing apps
 """
 from collections import Counter
 from ..marks import event_callback
+from ..apps import app
 from ..utils import get_logger
 
-
+@app
 class Bridger(object):
     '''Bridge sessions within a call an arbitrary number of times.
     '''

--- a/switchy/apps/routers.py
+++ b/switchy/apps/routers.py
@@ -9,6 +9,7 @@ from ..marks import event_callback
 from ..apps import app
 from ..utils import get_logger
 
+
 @app
 class Bridger(object):
     '''Bridge sessions within a call an arbitrary number of times.

--- a/switchy/cli.py
+++ b/switchy/cli.py
@@ -1,0 +1,162 @@
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 textwidth=80 smarttab expandtab
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import re
+import time
+import click
+import switchy
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command('list-apps')
+@click.argument('module', nargs=1, required=False)
+def list_apps(module):
+    builtin_mods = switchy.apps.load()
+    click.echo(
+        'Collected {} built-in apps from {} modules:\n'
+        .format(len(list(switchy.apps.iterapps())), len(builtin_mods))
+    )
+    for mod, apps in switchy.apps.groupbymod():
+        click.echo('{}:\n'.format(mod))
+        for name, app in apps:
+            click.echo('`{}`: {}'.format(
+                name, app.__doc__ or '(No help for app {})'.format(name))
+            )
+
+
+# XXX plot command is only available when matplotlib is installed
+@cli.command()
+@click.argument('file-name', nargs=1, required=True,
+                type=click.Path(exists=True))
+def plot(file_name):
+    import matplotlib
+    from switchy.apps.measure import metrics
+    m = metrics.load(file_name)
+    click.echo('Plotting {} ...\n'.format(file_name))
+    m.plot()
+
+
+@cli.command()
+@click.argument('slaves', nargs=-1, required=True)
+@click.option('--proxy',
+              default=None,
+              help='Hostname or IP address of the proxy '
+              'device (this is usually the device you are testing)',
+              required=True)
+@click.option('--profile',
+              default='internal',
+              help='Profile to use for outbound calls in the load slaves')
+@click.option('--rate',
+              default=None, help='Call rate')
+@click.option('--limit',
+              default=None, help='Maximum number of concurrent calls')
+@click.option('--max-offered',
+              default=None,
+              help='Maximum number of calls to place '
+              'before stopping the program')
+@click.option('--duration', default=None, help='Duration of calls in seconds')
+@click.option('--interactive/--non-interactive',
+              default=False,
+              help='Whether to jump into an interactive session '
+              'after setting up the call originator')
+@click.option('--debug/--no-debug',
+              default=False, help='Whether to enable debugging')
+@click.option('--app', default='Bert',
+              help='Switchy application to execute '
+              '(see list-apps command to list available apps)')
+@click.option('--metrics-file',
+              default=None, help='Store metrics at the given file location')
+def run(slaves, proxy, profile, rate, limit, max_offered,
+        duration, interactive, debug, app, metrics_file):
+    log = switchy.utils.log_to_stderr("INFO")
+
+    # Check if the specified (or default) app is valid
+    switchy.apps.load()
+    cls = switchy.apps.get(app)
+    if not cls:
+        raise click.ClickException('Unknown app {}. Use list-apps command '
+                                   'to list available apps'.format(app))
+
+    # TODO: get_originator() receives an apps tuple (defaults to Bert) to
+    # select the application we should accept --app multi argument list to
+    # set multiple apps
+    o = switchy.get_originator(
+        slaves,
+        apps=(cls,),
+        rate=int(rate) if rate else None,
+        limit=int(limit) if limit else None,
+        max_offered=int(max_offered) if max_offered else None,
+        duration=int(duration) if duration else None,
+        auto_duration=True if not duration else False,
+    )
+
+    # Prepare the originate string for each slave
+    # depending on the profile name and network settings
+    # configured for that profile in that particular slave
+    p = re.compile('.+?BIND-URL\s+?.+?@(.+?):(\d+).+?\s+',
+                   re.IGNORECASE | re.DOTALL)
+    for c in o.pool.clients:
+        status = c.client.api('sofia status profile {}'
+                              .format(profile)).getBody()
+        m = p.match(status)
+        if not m:
+            raise click.ClickException('Slave {} does not have a profile '
+                                       'named \'{}\' running'
+                                       .format(c.host, profile))
+        ip = m.group(1)
+        port = m.group(2)
+        # The originate cmd must route the call back to us using the specified
+        # proxy (the device under test)
+        log.info('Slave {} SIP address is at {}:{}'.format(c.host, ip, port))
+        c.set_orig_cmd(dest_url='switchy@{}:{}'.format(ip, port),
+                       profile=profile, app_name='park',
+                       proxy='{}'.format(proxy))
+
+    log.info('Starting load test for server {} at {}cps using {} slaves'
+               .format(proxy, o.rate, len(slaves)))
+    click.echo(o)
+    if interactive:
+        try:
+            import IPython
+            IPython.embed()
+        except ImportError:
+            try:
+                # optional, will allow Up/Down/History in the console
+                import readline
+            except ImportError:
+                pass
+            import code
+            vars = globals().copy()
+            vars.update(locals())
+            shell = code.InteractiveConsole(vars)
+            shell.interact()
+
+        o.shutdown()
+        click.echo(o)
+    else:
+        o.start()
+        while o.state != 'STOPPED':
+            try:
+                time.sleep(1)
+                click.echo(o)
+            except KeyboardInterrupt:
+                o.shutdown()
+                click.echo(o)
+
+    while True:
+        active_calls = o.count_calls()
+        if active_calls <= 0:
+            break
+        click.echo('Waiting on {} active calls to finish'.format(active_calls))
+        time.sleep(1)
+
+    if metrics_file:
+        click.echo('Storing test metrics at {}'.format(metrics_file))
+        o.metrics.dump(metrics_file)
+
+    click.echo('Load test finished!')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py27
+
+[testenv]
+# NOTE: ESL is a special janky case where you must provide the
+# paths to the locally installed ESL.py and _ESL.so via the environment
+# variables ESL_MOD_PATH and ESL_BIN_PATH respectively.
+# An example command should look something like:
+# "ESL_BIN_PATH=/usr/lib/python2.7/site-packages/_ESL.so \
+# ESL_MOD_PATH=/usr/lib/python2.7/site-packages/ESL.py \
+# tox2 -- --fshost=sip-cannon.qa.sangoma.local"
+args_are_paths = False
+deps =
+    pytest
+    click
+whitelist_externals = ln
+# usedevelop = True
+commands =
+    ln -fs {env:ESL_MOD_PATH} {envsitepackagesdir}/ESL.py
+    ln -fs {env:ESL_BIN_PATH} {envsitepackagesdir}/_ESL.so
+    py.test {posargs}


### PR DESCRIPTION
A command line is something needed if we want adoption by non Python programmers (which I think will be the majority of interested users).

These commits add a 'switchy' command with several sub-commands (like git does for 'git clone', git merge' etc)

The current sub-commands are:

list-apps (to list available apps)
run (to run a load test)
plot (to plot saved results)

In order to be able to list available apps and display help for users I introduced an @app decorator which applications should use. More details in the commit message ...