### PR TITLE
Convo load testing

### DIFF
--- a/switchy/apps/bert.py
+++ b/switchy/apps/bert.py
@@ -34,7 +34,7 @@ class Bert(object):
         self._two_sided = False  # toggle whether to run bert on both ends
 
         # make sure the module is loaded
-        client.api('reload mod_bert', exc=False)
+        client.api('reload mod_bert')
 
         # collections of failed sessions
         self.lost_sync = deque(maxlen=1e3)

--- a/switchy/apps/measure/metrics.py
+++ b/switchy/apps/measure/metrics.py
@@ -15,6 +15,7 @@ metric_dtype = np.dtype([
     ('answer_latency', np.float64),
     ('call_setup_latency', np.float64),
     ('originate_latency', np.float64),
+    ('originate_to_invite_latency', np.float64),
     ('num_failed_calls', np.uint32),
     ('num_sessions', np.uint32),
 ])
@@ -173,6 +174,7 @@ else:
                 ('call_setup_latency', (1, 1)),
                 ('invite_latency', (1, 1)),
                 ('originate_latency', (1, 1)),
+                ('originate_to_invite_latency', (1, 1)),
                 # counts
                 ('num_sessions', (2, 1)),  # concurrent calls at creation time
                 ('num_failed_calls', (2, 1)),

--- a/switchy/observe.py
+++ b/switchy/observe.py
@@ -968,7 +968,7 @@ class Client(object):
         # generally speaking clients should only host one call app
         self._apps = {}
         self.apps = type('apps', (), {})()
-        self.apps.__dict__ = self._apps  # dot-access to apps from 'apps' attr
+        self.apps.__dict__ = self._apps  # dot-access to `_apps` from `apps`
         self.client = self  # for app funcarg insertion
 
         # WARNING: order of these next steps matters!

--- a/switchy/utils.py
+++ b/switchy/utils.py
@@ -204,6 +204,17 @@ def uuid():
     return str(mod_uuid.uuid1())
 
 
+def get_event_time(event, epoch=0.0):
+    '''Return micro-second time stamp value in seconds
+    '''
+    value = event.getHeader('Event-Date-Timestamp')
+    if value is None:
+        get_logger().warning("Event '{}' has no timestamp!?".format(
+                             event.getHeader("Event-Name")))
+        return None
+    return float(value) / 1e6 - epoch
+
+
 class FastScheduler(sched.scheduler):
 
     def next_event_time_delta(self):

--- a/tests/apps/test_originator.py
+++ b/tests/apps/test_originator.py
@@ -70,7 +70,12 @@ def test_convo_sim(get_orig):
 
     orig = get_orig(
         'doggy',
-        apps=[(players.PlayRec, {'rec_stereo': True, 'callback': count})]
+        apps=[
+            (players.PlayRec,
+             {'rec_stereo': True,
+              'callback': count,
+              'dynamic_rec_rate': True})
+        ]
     )
     # manual app reference retrieval
     playrec = orig.pool.nodes[0].client.apps.PlayRec
@@ -78,7 +83,7 @@ def test_convo_sim(get_orig):
     # verify dynamic load settings modify playrec settings
     orig.rate = 10
     orig.limit = orig.max_offered = 100
-    assert playrec.rec_rate == orig.rate
+    assert playrec.rec_rate == orig.rate * playrec.rec_period
     assert playrec.iterations * playrec.clip_length + playrec.tail == orig.duration
 
     orig.start()

--- a/tests/apps/test_originator.py
+++ b/tests/apps/test_originator.py
@@ -2,15 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 '''
-Originator testing
+`Originator` testing
 
 .. note::
-    these tests assume that the switchy dialplan has been set for the
-    `external` profile's context.
+    these tests assume that the `external` sip profile's context
+    has been assigned to the switchy dialplan.
 '''
 import pytest
 import time
-from switchy.apps import dtmf
+from switchy.apps import dtmf, players
 from switchy import get_originator
 
 
@@ -19,10 +19,17 @@ def get_orig(request, fsip):
     '''Deliver an `Originator` app which drives a single
     FreeSWITCH slave process.
     '''
-    apps = request.node.get_marker('apps')
-    orig = get_originator(fsip, apps=apps.kwargs.values())
+    origs = []
 
-    def conf_orig(userpart, port=5080, limit=1, rate=1, offer=1):
+    def factory(userpart, port=5080, limit=1, rate=1, offer=1, **kwargs):
+        orig = get_originator(
+            fsip,
+            limit=limit,
+            rate=rate,
+            max_offered=offer,
+            **kwargs
+        )
+
         # each slave profile should call originate calls to itself
         # to avoid dependency on another server
         orig.pool.evals(
@@ -31,20 +38,18 @@ def get_orig(request, fsip):
             userpart=userpart,
             port=port,
         )
-        # dut should provide these values based on hw resources
-        orig.limit = limit
-        orig.rate = rate
-        orig.max_offered = offer
+        origs.append(orig)
         return orig
-    yield conf_orig
-    orig.shutdown()
+
+    yield factory
+    for orig in origs:
+        orig.shutdown()
 
 
-@pytest.mark.apps(dtmf=dtmf.DtmfChecker)
 def test_dtmf_passthrough(get_orig):
     '''Test the dtmf app in coordination with the originator
     '''
-    orig = get_orig('doggy', offer=1)
+    orig = get_orig('doggy', offer=1, apps=(dtmf.DtmfChecker,))
     orig.duration = 0
     orig.start()
     checker = orig.pool.clients[0].apps.DtmfChecker
@@ -53,3 +58,33 @@ def test_dtmf_passthrough(get_orig):
     assert not any(orig.pool.evals('client.apps.DtmfChecker.incomplete'))
     assert not any(orig.pool.evals('client.apps.DtmfChecker.failed'))
     assert orig.state == "STOPPED"
+
+
+def test_convo_sim(get_orig):
+    """Test the `PlayRec` app when used for a load test with the `Originator`
+    """
+    recs = []
+
+    def count(recinfo):
+        recs.append(recinfo)
+
+    playrec = players.PlayRec(rec_stereo=True, callback=count,)
+    orig = get_orig('doggy', apps=(playrec,),)
+
+    # verify dynamic load settings modify playrec settings
+    orig.rate = 10
+    orig.limit = orig.max_offered = 100
+    assert playrec.rec_rate == orig.rate
+    assert playrec.iterations * playrec.clip_length + playrec.tail == orig.duration
+
+    orig.start()
+    # ensure calls are set up fast enough
+    time.sleep(float(orig.limit / orig.rate) + 1.0)
+    assert orig.pool.count_calls() == orig.limit
+
+    # wait for all calls to end
+    while not orig.stopped() or orig.pool.count_calls():
+        time.sleep(1)
+
+    # ensure number of calls recorded matches the rec rate
+    assert len(recs) == int(orig.max_offered / playrec.rec_rate)

--- a/tests/apps/test_originator.py
+++ b/tests/apps/test_originator.py
@@ -68,8 +68,12 @@ def test_convo_sim(get_orig):
     def count(recinfo):
         recs.append(recinfo)
 
-    playrec = players.PlayRec(rec_stereo=True, callback=count,)
-    orig = get_orig('doggy', apps=(playrec,),)
+    orig = get_orig(
+        'doggy',
+        apps=[(players.PlayRec, {'rec_stereo': True, 'callback': count})]
+    )
+    # manual app reference retrieval
+    playrec = orig.pool.nodes[0].client.apps.PlayRec
 
     # verify dynamic load settings modify playrec settings
     orig.rate = 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,7 +102,7 @@ def el(fshost):
     assert not el.is_alive()
 
 
-@pytest.yield_fixture(scope='class')
+@pytest.yield_fixture
 def client(fshost):
     """Deliver a core.Client connected to fshost
     """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,7 +95,7 @@ def proxy_dp(ael, client):
         if sess['Call-Direction'] == 'inbound':
             sess.bridge(dest_url="${sip_req_uri}")
 
-    ev = "CHANNEL_PARK"
+    ev = "CHANNEL_PARK"  # no answer() is ever done...
     # add a failover callback to provide the dialplan
     ael.add_callback(ev, 'default', bridge2dest)
     # ensure callback was registered

--- a/tests/test_sync_call.py
+++ b/tests/test_sync_call.py
@@ -34,7 +34,7 @@ def test_playrec(fsip):
     '''
     with sync_caller(fsip, apps={"PlayRec": PlayRec}) as caller:
         # have the external prof call itself by default
-        caller.apps.PlayRec.sim_convo = True
+        caller.apps.PlayRec.rec_rate = 1
         sess, waitfor = caller(
             "doggy@{}:{}".format(caller.client.server, 5080),
             'PlayRec',


### PR DESCRIPTION
This adds conversation simulating apps via `PlayRec` and `MutedPlayRec` with support for load testing using the `Originator`. I by no means expect this code to be reviewed quickly but it would be helpful to have another set of eyes especially when it comes to the size of these new apps. 

I'm not super fond of the logic being strongly coupled to `Session` state manipulation but I don't know how else to implement it currently without re-thinking the whole app system.

Opinions and recommendations are welcome.