### PR TITLE
Check that session is hungup in DTMF timeout thread.

### DIFF
--- a/examples/ivr/call_logic.py
+++ b/examples/ivr/call_logic.py
@@ -219,6 +219,10 @@ class IVRCallLogic(object):
     def dtmf_timeout_action(self, sess):
         """Timer handler that implements DTMF timeout
         """
+
+        if sess.hungup is True:
+            return
+
         call = sess.call
         log.info("'{}': DTMF timeout".format(sess.uuid))
 


### PR DESCRIPTION
Without this check, the DTMF timeout threads will never end for hungup sessions.
Causing thread leaks which in the end kill the application.
