### PR TITLE
Bert ring response

### DIFF
--- a/switchy/commands.py
+++ b/switchy/commands.py
@@ -54,6 +54,7 @@ def build_originate_cmd(dest_url, uuid_str=None, profile='external',
         # must fill this in using a format string placeholder
         'origination_uuid': uuid_str or '{uuid_str}',
         'ignore_display_updates': 'true',
+        'ignore_early_media': 'true',
     }
 
     # set a proxy destination if provided (i.e. the first hop)

--- a/switchy/models.py
+++ b/switchy/models.py
@@ -220,7 +220,7 @@ class Session(object):
         if tone_duration is not None:
             cmd += ' @{}'.format(tone_duration)
 
-        self.con.api(cmd)
+        return self.con.api(cmd)
 
     def send_dtmf(self, sequence, duration='w'):
         '''Send a dtmf sequence with constant tone durations
@@ -327,12 +327,24 @@ class Session(object):
         '''
         self.con.api('uuid_park {}'.format(self.uuid))
 
-    def broadcast(self, path, leg='', hangup_cause=None):
-        """Execute an application on a chosen leg(s) with optional hangup
-        afterwards.
-        ``uuid_broadcast <uuid> app[![hangup_cause]]::args [aleg|bleg|both]``
+    def broadcast(self, path, leg='', delay=None, hangup_cause=None):
+        """Execute an application async on a chosen leg(s) with optional hangup
+        afterwards. If provided tell FS to schedule the app ``delay`` seconds
+        in the future. Uses either of the `uuid_broadcast`_ or
+        `sched_broadcast`_ commands.
+
+        .. _uuid_broadcast:
+            https://freeswitch.org/confluence/display/FREESWITCH/mod_commands#mod_commands-uuid_broadcast
+        .. _sched_broadcast:
+            https://freeswitch.org/confluence/display/FREESWITCH/mod_commands#mod_commands-sched_broadcast
         """
-        self.con.api('uuid_broadcast {} {} {}'.format(self.uuid, path, leg))
+        if not delay:
+            return self.con.api(
+                'uuid_broadcast {} {} {}'.format(self.uuid, path, leg))
+        else:
+            return self.con.api(
+                'sched_broadcast +{} {} {}'.format(delay, self.uuid, path, leg)
+            )
 
     def bridge(self, dest_url=None, profile=None, gateway=None, proxy=None,
                params=None):


### PR DESCRIPTION
Add ring response, pdd, and prd (post ring) parameters to the `Bert` testing app.

To simplify the implementation, instead of having a separate callback to trigger a future scheduled `answer` command, I simply add the `pdd` to the `prd` delay and schedule both immediately.

I was also debating  applying a `0.99` factor to each of `pdd`, `prd` to account for FS processing delays.

I'd be interested to hear any opinions :)