### PR TITLE
Service cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ switchy
 =======
 |pypi| |versions| |pypi_downloads| |docs|
 
-FreeSWITCH_ control and stress testing using pure Python_.
+Async FreeSWITCH_ cluster control using pure Python_.
 
 `switchy` intends to become the "flask_ for VoIP" but with a focus on performance and
 scalable service system design.

--- a/docs/cmdline.rst
+++ b/docs/cmdline.rst
@@ -1,7 +1,9 @@
-Command line
-============
-Switchy provides a convenient cli to initiate load tests with the help
-of click_. The program is installed as binary `switchy`::
+.. _cli_client:
+
+Command line client
+===================
+``switchy`` provides a convenient cli to initiate auto-dialers and call control services with
+the help of click_. The program is installed as binary ``switchy``::
 
     $ switchy
     Usage: switchy [OPTIONS] COMMAND [ARGS]...
@@ -12,9 +14,13 @@ of click_. The program is installed as binary `switchy`::
     Commands:
       list-apps
       plot
-      run
+      dial
+      serve
 
 A few sub-commands are provided.
+
+Listing apps
+------------
 For example you can list the applications available (:doc:`apps` determine call flows)::
 
     $ switchy list-apps
@@ -52,11 +58,13 @@ For example you can list the applications available (:doc:`apps` determine call 
     `Bridger`: Bridge sessions within a call an arbitrary number of times.  
 
 
-The applications listed can be used with the `app` option to the `run` sub-command.
-`run` is the main sub-command used to start a load test. Here is the help::
+Spawning the auto-dialer
+------------------------
+The applications listed can be used with the `app` option to the `dial` sub-command.
+`dial` is the main sub-command used to start a load test. Here is the help::
 
-    $ switchy run --help
-    Usage: switchy run [OPTIONS] SLAVES...
+    $ switchy dial --help
+    Usage: switchy dial [OPTIONS] HOSTS...
 
     Options:
       --proxy TEXT                    Hostname or IP address of the proxy device
@@ -79,9 +87,9 @@ The applications listed can be used with the `app` option to the `run` sub-comma
       --help                          Show this message and exit.
 
 
-The `SLAVES` argument can be one or more IP's or hostnames for each configured FreeSWITCH process
-used to originate traffic. The `proxy` option is required and must be the IP address or hostname
-of the device you are testing. All slaves will direct traffic to the specified proxy.
+The `HOSTS` argument can be one or more IP's or hostnames for each configured FreeSWITCH process
+used to originate traffic. The `proxy` option is required and must be the hostname of the first hop;
+all hosts will direct traffic to this proxy.
 
 The other options are not strictly required but typically you will want to at least specify a given call rate
 using the `rate` option, max number of concurrent calls (erlangs) with `limit` and possibly max number of
@@ -90,19 +98,25 @@ calls offered with `max-offered`.
 For example, to start a test using an slave located at `1.1.1.1` to test device at `2.2.2.2` with a maximum of
 `2000` calls at `30` calls per second and stopping after placing `100,000` calls you can do::
 
-    $ switchy run 1.1.1.1 --profile external --proxy 2.2.2.2 --rate 30 --limit 2000 --max-offered 100000
+    $ switchy dial 1.1.1.1 --profile external --proxy 2.2.2.2 --rate 30 --limit 2000 --max-offered 100000
 
     Slave 1.1.1.1 SIP address is at 1.1.1.1:5080
     Starting load test for server 2.2.2.2 at 30cps using 1 slaves
     ...
 
-Note that the `profile` option is also important and the profile must exist already for all specified slaves.
+Note that the `profile` option is also important and the profile must already exist.
 
-In this case the call duration would be automatically calculated to sustain that call rate and that max calls
-exactly, but you can tweak the call duration in seconds using the `duration` option.
+In this case the call duration would be automatically calculated to sustain that call
+rate and that max calls exactly, but you can tweak the call duration in seconds using
+the `duration` option.
 
 Additionally you can use the `metrics-file` option to store call metrics in a file.
 You can then use the `plot` sub-command to generate graphs of the collected data using
 `matplotlib` if installed.
+
+Launching a cluster routing service
+-----------------------------------
+You can also launch cluster controllers using ``switchy serve``.
+See :ref:`services` for more details.
 
 .. _click: http://click.pocoo.org/5/

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,7 +11,7 @@ Assuming you've gone through the required :doc:`deployment steps
 <fsconfig>` to setup at least one slave, initiating a call becomes
 very simple using the Switchy command line::
 
-    $ switchy run vm-host sip-cannon --profile external --proxy myproxy.com --rate 1 --limit 1 --max-offered 1
+    $ switchy dial vm-host sip-cannon --profile external --proxy myproxy.com --rate 1 --limit 1 --max-offered 1
 
     ...
 
@@ -27,13 +27,12 @@ very simple using the Switchy command line::
     Waiting on 1 active calls to finish
     Waiting on 1 active calls to finish
     Waiting on 1 active calls to finish
-    Load test finished!
+    Dialing session completed!
 
 
-The Switchy `run` sub-command takes several options and a list
-of slaves (or at least one) IP address or hostname. In this
-example switchy connected to the specified slaves, found the specified SIP
-profile and initiated a single call with a duration of 5 seconds to the
+The Switchy `dial` sub-command takes several options and a list of minion IP addresses
+or hostnames. In this example ``switchy`` connected to the specified hosts, found the
+requested SIP profile and initiated a single call with a duration of 5 seconds to the
 device under test (set with the `proxy` option).
 
 For more information on the switchy command line see :doc:`here <cmdline>`.

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -53,11 +53,16 @@ Simply specify the list of FreeSWITCH hosts to connect to and specify
 the desired :doc:`app(s) <apps>` which should be loaded using (multiples
 of) the ``--app`` option::
 
-    switchy serve freeswitch1.net freeswitch2.net --app Proxier
+    switchy serve freeswitch1.net freeswitch2.net --app switchy.apps.routers:Proxier
 
 This runs the example from above.
+You can also load apps from arbitrary Python modules you've written::
+
+    switchy serve freeswitch1.net freeswitch2.net --app ./path/to/dialplan.py:router
 
 .. note::
+    The name specified **after** the ``':'`` is the attribute that
+    will be ``getattr``-ed on the module.
     You can specify ``--loglevel`` for detailed logging.
 
 .. _flask-like:
@@ -70,6 +75,7 @@ can define a routing system reminiscent of `flask`_.
 Let's start with an example of `blocking certain codes`_:
 
 .. code-block:: python
+    :caption: dialplan.py
 
     from switchy.apps.routers import Router
 
@@ -110,6 +116,15 @@ and works by taking in a `regex` ``pattern``, an optional ``field`` (default
 is ``'Caller-Destination-Number'``) and ``kwargs``.
 The ``pattern`` must be matched against the ``field`` *event header* in order for
 the *route* to be called with ``kwargs`` (i.e. ``reject_international(**kwargs)``).
+
+
+You can run this app directly using ``switchy serve``::
+
+    switchy serve freeswitch1.net freeswitch2.net --app ./dialplan.py:router
+
+.. note::
+    In the case above this is the ``Router`` *instance* which has
+    `route` function (``reject_international``) already registered.
 
 Let's extend our example to include some routes which `bridge`_ differently
 based on the default ``'Caller-Destination-Number'`` *event header*:

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -1,4 +1,3 @@
-.. _services:
 .. toctree::
     :maxdepth: 2
     :hidden:
@@ -6,6 +5,8 @@
     api
     apps
 
+
+.. _services:
 
 Building a cluster service
 ==========================
@@ -44,6 +45,20 @@ In this example all three of our *FreeSWITCH* servers load a `Proxier`
 the SIP Request-URI header. The `app_id='default'` kwarg is required to tell
 the internal event loop that this app should be used as the default (i.e. when
 no other app has consumed the event/session for processing).
+
+Launching a service
+-------------------
+You can launch ``switchy`` services using the :ref:`cli client <cli_client>`.
+Simply specify the list of FreeSWITCH hosts to connect to and specify
+the desired :doc:`app(s) <apps>` which should be loaded using (multiples
+of) the ``--app`` option::
+
+    switchy serve freeswitch1.net freeswitch2.net --app Proxier
+
+This runs the example from above.
+
+.. note::
+    You can specify ``--loglevel`` for detailed logging.
 
 .. _flask-like:
 

--- a/switchy/apps/routers.py
+++ b/switchy/apps/routers.py
@@ -121,7 +121,7 @@ class Router(object):
         """Signal a router to discontinue execution.
         """
 
-    def __init__(self, guards, reject_on_guard=True):
+    def __init__(self, guards=None, reject_on_guard=True):
         self.guards = guards or {}
         self.guard = reject_on_guard
         self.route = PatternRegistrar()

--- a/switchy/observe.py
+++ b/switchy/observe.py
@@ -1014,11 +1014,13 @@ class Client(object):
         )
         failed = False
         cb_paths = []
+        handler_paths = []
         # insert handlers and callbacks
         for ev_type, cb_type, obj in marks.get_callbacks(app):
             if cb_type == 'handler':
                 # TODO: similar unloading on failure here as above?
                 listener.add_handler(ev_type, obj)
+                handler_paths.append(ev_type, obj)
 
             elif cb_type == 'callback':
                 # add default handler if none exists
@@ -1043,8 +1045,13 @@ class Client(object):
                                .format(ev_type, obj.__name__, group_id))
 
         if failed:
-            raise TypeError("app load failed since '{}' is not a valid"
+            raise TypeError("App load failed since '{}' is not a valid"
                             "callback type".format(failed))
+        if not cb_paths and not handler_paths:
+            raise TypeError(
+                "Failed to load '{}' no callbacks or handlers could be found"
+                .format(name)
+            )
 
         # prepend the provided header to use for app id look ups
         # TODO: should probably be moved into `add_callback()`?

--- a/switchy/serve.py
+++ b/switchy/serve.py
@@ -13,14 +13,15 @@ class Service(object):
     """Serve centralized, long running, call processing apps on top of a
     FreeSWITCH cluster.
     """
-    def __init__(self, contacts):
-        self.pool = get_pool(
-            contacts, call_tracking_header='variable_call_uuid')
+    def __init__(self, contacts, **kwargs):
+        kwargs.setdefault('call_tracking_header', 'variable_call_uuid')
+        self.pool = get_pool(contacts, **kwargs)
         self.apps = AppManager(self.pool)
         self.host = self.pool.evals('listener.host')
         self.log = utils.get_logger(utils.pstr(self))
         # initialize all reactor event loops
         self.pool.evals('listener.connect()')
+        self.pool.evals('client.connect()')
 
     def run(self, block=True):
         """Run service optionally blocking until stopped.


### PR DESCRIPTION
Adds `switchy serve` for launching cluster control services easily from the CLI.
This makes it super easy to test call processing apps and connections to remote FS hosts.

This was original instigated by #62 so thanks to  @k4ml for the initial request :+1: 