### PR TITLE
Allow 'switchy dial' to specify application arguments

### DIFF
--- a/switchy/utils.py
+++ b/switchy/utils.py
@@ -51,7 +51,7 @@ def log_to_stderr(level=None):
     '''
     log = logging.getLogger()  # the root logger
     if level:
-        log.setLevel(level)
+        log.setLevel(level.upper())
     if not any(
         handler.stream == sys.stderr for handler in log.handlers
         if getattr(handler, 'stream', None)


### PR DESCRIPTION
This allows ```switchy dial``` to specify arguments for the applications, e.g:

```
switchy dial --app Bert/arg1=val1,arg2=val2
```